### PR TITLE
Add support for multiple capture fields (#160)

### DIFF
--- a/src/options/options.js
+++ b/src/options/options.js
@@ -123,7 +123,7 @@ const updateErrors = () => {
 
           const value = document.createElement("div");
           value.className = "match-row-result";
-          value.textContent = body.routeInfo.captures[i];
+          value.textContent = body.routeInfo.captures[i + 1];
           div.appendChild(value);
 
           return div;


### PR DESCRIPTION
Implements #160 

**Multiple fields:**

![firefox_SC14PoncHG](https://user-images.githubusercontent.com/101566269/158507672-40967c9e-6f6c-4884-97c8-0b997d2cfe94.png)

**Single field:**

![6xrrKt9RJj](https://user-images.githubusercontent.com/101566269/158507620-c3321c77-b16a-425b-9889-c81bee697291.png)

As you can see, the matched URL is included in the results.
I was not sure whether or not to remove this, as technically it was previously possible to retrieve this via `$0`
Also, perhaps this could use some tests. Please let me know and I will add them.

Linter and tests all passed.

Signed-off-by: Maddy <maddykakkoheart@protonmail.com