### PR TITLE
Maybe it would be easier to not experiment with awaits?

### DIFF
--- a/src/history.js
+++ b/src/history.js
@@ -4,9 +4,10 @@ const HISTORY_KEY = "save-in-history";
 
 const SaveHistory = {
   add: async (entry) => {
-    const current = (await browser.storage.local.get(HISTORY_KEY)) || {};
-    await browser.storage.local.set({
-      [HISTORY_KEY]: [...(current.history || []), entry],
+    browser.storage.local.get(HISTORY_KEY, function(current) {
+      browser.storage.local.set({
+        [HISTORY_KEY]: [...((current || {})[HISTORY_KEY] || []), entry],
+      })
     });
   },
   get: async () => (await browser.storage.local.get(HISTORY_KEY)) || [],


### PR DESCRIPTION
Seems to solve #159.

Frankly, most likely the actual error is that it should be `current[HISTORY_KEY]` instead of `current.history`, but maybe it would be safer to get rid of those awaits as well.